### PR TITLE
Fix link to Kinesis repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 ## References
 *References for additional information about the Kinesis keyboard*
--   [Advantage2-SmartSet-App](https://github.com/KinesisCorporation/SmartSetApps) - Open sourced GUI for modifying the Advantage 2
+-   [KinesisCorporation/SmartSetApps](https://github.com/KinesisCorporation/SmartSetApps) - SmartSet apps for keyboards, foots pedals and more 
 -   [Keyboard layouts and macros for the Kinesis Advantage 2 keyboard.](https://github.com/farmergreg/kinesis-advantage-2) - Optimizing Kinesis usage for vim, programming, gaming and more!
 -   [Keycap Replacement Charts](https://deskthority.net/wiki/Kinesis_Contoured#Keycaps) - by way of Deskthority
 -   [@kinesisergo on Twitter](https://twitter.com/kinesisergo) - Kinesis Ergo on Twitter

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 ## References
 *References for additional information about the Kinesis keyboard*
--   [Advantage2-SmartSet-App](https://github.com/KinesisCorporation/Advantage2-SmartSet-App) - Open sourced GUI for modifying the Advantage 2
+-   [Advantage2-SmartSet-App](https://github.com/KinesisCorporation/SmartSetApps) - Open sourced GUI for modifying the Advantage 2
 -   [Keyboard layouts and macros for the Kinesis Advantage 2 keyboard.](https://github.com/farmergreg/kinesis-advantage-2) - Optimizing Kinesis usage for vim, programming, gaming and more!
 -   [Keycap Replacement Charts](https://deskthority.net/wiki/Kinesis_Contoured#Keycaps) - by way of Deskthority
 -   [@kinesisergo on Twitter](https://twitter.com/kinesisergo) - Kinesis Ergo on Twitter


### PR DESCRIPTION
Updating old link to the Kinesis SmartSet app. It looks like Kinesis moved to using a new repository, "SmartSetApps", per this bug comment:

- https://github.com/KinesisCorporation/Advantage2-SmartSet-App/issues/2#issuecomment-614788032